### PR TITLE
UN-8536: updates for M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 export DOCKER_ORG ?= unionpos
 export DOCKER_IMAGE ?= $(DOCKER_ORG)/couchbase-enterprise-server
-export DOCKER_TAG ?= 6.5.0
+export DOCKER_TAG ?= 7.0.2
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
-export DOCKER_BUILD_FLAGS =
+export DOCKER_BUILD_FLAGS = --platform linux/amd64
 
 -include $(shell curl -sSL -o .build-harness "https://raw.githubusercontent.com/unionpos/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ push:
 .PHONY: push
 
 run:
-	$(DOCKER) container run --rm --platform linux/amd64 \
+	$(DOCKER) container run --rm ${DOCKER_BUILD_FLAGS} \
 		--publish "8091-8096:8091-8096" \
 		--publish "18091-18096:18091-18096" \
 		--publish "11207:11207" \
@@ -27,5 +27,5 @@ run:
 .PHONY: run
 
 it:
-	$(DOCKER) run -it --platform linux/amd64 ${DOCKER_IMAGE_NAME} /bin/bash
+	$(DOCKER) run -it ${DOCKER_BUILD_FLAGS} ${DOCKER_IMAGE_NAME} /bin/bash
 .PHONY: it

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ push:
 .PHONY: push
 
 run:
-	$(DOCKER) container run --rm \
+	$(DOCKER) container run --rm --platform linux/amd64 \
 		--publish "8091-8096:8091-8096" \
 		--publish "18091-18096:18091-18096" \
 		--publish "11207:11207" \
@@ -27,5 +27,5 @@ run:
 .PHONY: run
 
 it:
-	$(DOCKER) run -it ${DOCKER_IMAGE_NAME} /bin/bash
+	$(DOCKER) run -it --platform linux/amd64 ${DOCKER_IMAGE_NAME} /bin/bash
 .PHONY: it

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # shellcheck disable=SC1091
-source "/usr/local/lib/bashui.sh"
+source "/usr/local/bashlib/bashui.sh"
 
 staticConfigFile=/opt/couchbase/etc/couchbase/static_config
 restPortValue=8091


### PR DESCRIPTION
## What and Why
Updates couchbase image for enterprise server 7.0.2.  

Available on docker hub as `unionpos/couchbase-enterprise-server:7.0.2`

## Related Tickets and PRs

Fixes [UN-8536](https://tabbedout.atlassian.net/browse/UN-8536)

## Steps to Test


## Humor for Reviewer

[UN-8536]: https://tabbedout.atlassian.net/browse/UN-8536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ